### PR TITLE
Add flow for user reset password

### DIFF
--- a/src/WebApp/Pages/Account/Forgot-Password.cshtml
+++ b/src/WebApp/Pages/Account/Forgot-Password.cshtml
@@ -1,0 +1,30 @@
+﻿@page
+@model ForgotPasswordModel
+
+<form asp-page="/account/forgot-password" method="post">
+    <div class="has-padding-2">
+        <h1>Forgot Password</h1>
+        <p>Sometimes we forget our password but thats okay, we can help you out. Don't have an account? <a asp-page="Register">Sign up instead.</a></p>
+    </div>
+    <partial name="_ValidationSummary" />
+    <div class="widget">
+        @if (Model.Sent == false)
+        {
+            <div class="widget--body">
+                <div class="has-padding-1">
+                    <label asp-for="Email" class="form-element">E-Mail Address</label>
+                    <input asp-for="Email" type="email" class="form-element" id="email">
+                </div>
+            </div>
+            <div class="widget--footer">
+                <button type="submit" class="button is-filled">Send email</button>
+            </div>
+        }
+        else
+        {
+            <div class="widget--body">
+                <p>Email has been sent to the provided email.</p>
+            </div>
+        }
+    </div>
+</form>

--- a/src/WebApp/Pages/Account/Forgot-Password.cshtml.cs
+++ b/src/WebApp/Pages/Account/Forgot-Password.cshtml.cs
@@ -1,0 +1,45 @@
+﻿using Codidact.Authentication.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+namespace Codidact.Authentication.WebApp.Pages.Account
+{
+    [BindProperties]
+    public class ForgotPasswordModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public ForgotPasswordModel(
+                          UserManager<ApplicationUser> userManager
+            )
+        {
+            _userManager = userManager;
+        }
+
+        [Required(ErrorMessage = "E-Mail Address is required")]
+        [DataType(DataType.EmailAddress)]
+        public string Email { get; set; }
+
+        public bool Sent { get; set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (ModelState.IsValid)
+            {
+                var user = await _userManager.FindByEmailAsync(Email);
+                if (user != null)
+                {
+                    var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+                    // TODO: Send Email with the token
+                    // _emailService.SendResetPassowrd(Email, result);
+                }
+                Sent = true;
+            }
+
+            return Page();
+        }
+    }
+}

--- a/src/WebApp/Pages/Account/Login.cshtml
+++ b/src/WebApp/Pages/Account/Login.cshtml
@@ -5,6 +5,8 @@
         <div class="has-padding-2">
             <h1>Sign in</h1>
             <p>Welcome to Codidact! You can login to your account here. Don't have an account? <a asp-page="Register">Sign up instead.</a></p>
+            <p>Forgot your password? <a asp-page="Forgot-Password">Click here to recover it.</a></p>
+
         </div>
         <input asp-for="ReturnUrl" type="hidden" />
 

--- a/src/WebApp/Pages/Account/Reset-Password.cshtml
+++ b/src/WebApp/Pages/Account/Reset-Password.cshtml
@@ -1,0 +1,34 @@
+﻿@page
+@model ResetPasswordModel
+
+    <form asp-page="/account/reset-password" method="post">
+        <div class="has-padding-2">
+            <h1>Reset your password</h1>
+        </div>
+        <input asp-for="Token" type="hidden" />
+        <input asp-for="ReturnUrl" type="hidden" />
+        <input asp-for="Email" type="hidden" />
+
+        <partial name="_ValidationSummary" />
+
+        <div class="widget">
+            <div class="widget--body">
+                <div class="has-padding-1">
+                    <div class="has-padding-1">
+                        <label asp-for="Password" class="form-element">Password</label>
+                        <input asp-for="Password" class="form-element" type="password">
+                        <p class="form-caption">Choose a strong one. At least 8 characters are recommended. Don't choose common words or names.</p>
+                    </div>
+
+                    <div class="has-padding-1">
+                        <label asp-for="ConfirmPassword" class="form-element">Repeat your password</label>
+                        <input asp-for="ConfirmPassword" class="form-element" type="password">
+                        <p class="form-caption">We want to make sure, that you don't accidentally misspell your password.</p>
+                    </div>
+                </div>
+                <div class="widget--footer">
+                    <button type="submit" class="button is-filled">Reset password</button>
+                </div>
+            </div>
+        </div>
+    </form>

--- a/src/WebApp/Pages/Account/Reset-Password.cshtml.cs
+++ b/src/WebApp/Pages/Account/Reset-Password.cshtml.cs
@@ -1,0 +1,81 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Codidact.Authentication.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Codidact.Authentication.WebApp.Pages.Account
+{
+
+    [BindProperties]
+    public class ResetPasswordModel : PageModel
+    {
+
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public ResetPasswordModel(
+                          UserManager<ApplicationUser> userManager
+            )
+        {
+            _userManager = userManager;
+        }
+
+        [Required(ErrorMessage = "Password is required")]
+        [DataType(DataType.Password)]
+        public string Password { get; set; }
+
+        [Required(ErrorMessage = "Password Confirmaton is required")]
+        [DataType(DataType.Password)]
+        public string ConfirmPassword { get; set; }
+
+        [Required]
+        public string ReturnUrl { get; set; } = "/index";
+
+        [Required(ErrorMessage = "Invalid reset password form")]
+        public string Token { get; set; }
+
+        [Required(ErrorMessage = "Invalid reset password form")]
+        public string Email { get; set; }
+
+        public void OnGet([FromQuery] string token, [FromQuery]string returnUrl, [FromQuery]string email)
+        {
+            Token = token;
+            ReturnUrl = returnUrl;
+            Email = email;
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (Password.Equals(ConfirmPassword, System.StringComparison.InvariantCulture))
+            {
+                ModelState.AddModelError("ConfirmPassword", "Password and Password Confirmation must match");
+            }
+            if (ModelState.IsValid)
+            {
+                var user = await _userManager.FindByEmailAsync(Email);
+                if (user == null)
+                {
+                    ModelState.AddModelError("Email", "Email not found");
+                }
+                else
+                {
+                    var result = await _userManager.ResetPasswordAsync(user, Token, Password);
+                    if (!result.Succeeded)
+                    {
+                        foreach (var error in result.Errors)
+                        {
+                            ModelState.AddModelError(error.Code, error.Description);
+                        }
+                    }
+                    else
+                    {
+                        return RedirectToPage("Login");
+                    }
+                }
+            }
+
+            return Page();
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/codidact/authentication/issues/13

/account/forgot-password displays a form to enter an email to do a forget password.
On post creates a token and sends it to an email (not implemented)

/account/reset-password?token&email&returnUrl
Displays a form to enter new password and its confirmation.
On posts resets the passwords and moves to the login page.

What is not implemented:
The sending of the email.
How are we supposed to send the email?
Should this be part of the auth project?
How to do the templates?

[![Image from Gyazo](https://i.gyazo.com/f67072601e344eb0a5b91b475404f5ee.png)](https://gyazo.com/f67072601e344eb0a5b91b475404f5ee)

[![Image from Gyazo](https://i.gyazo.com/ee097b56f646cff72538f232bdac6ae4.png)](https://gyazo.com/ee097b56f646cff72538f232bdac6ae4)

[![Image from Gyazo](https://i.gyazo.com/905f8f82c81ced42889b6af0b5e76fa2.png)](https://gyazo.com/905f8f82c81ced42889b6af0b5e76fa2)